### PR TITLE
Fix markdown on /join/howtoapply

### DIFF
--- a/join/howtoapply.md
+++ b/join/howtoapply.md
@@ -3,7 +3,7 @@ layout: page
 title: PhD opportunities
 subtitle: How to apply for a PhD
 ---
-## PhD opportunities
+## PhD opportunities
  
 A PhD in physics provides you with problem solving and analytical skills which can be applied to a range of careers. A PhD from the QLM group will provide you with expert training in AMO and quantum physics.
  


### PR DESCRIPTION
The first title (PhD opportunities) is broken on the current website:

<https://durham-qlm.github.io/join/howtoapply/>

This is because the character after `##` is not a space, but a no-break space. This breaks markdown parsing. This changes it to a space.

Unicode: U+00A0 -> U+0020

via [WUCIT](https://www.babelstone.co.uk/Unicode/whatisit.html):

![image](https://github.com/durham-qlm/durham-qlm.github.io/assets/13833017/6530a6df-7668-49e6-94e3-2216659e5e58)
